### PR TITLE
Properly align entity id property docblock

### DIFF
--- a/Resources/views/skeleton/entity/_properties.php.twig
+++ b/Resources/views/skeleton/entity/_properties.php.twig
@@ -4,11 +4,11 @@
 {%- if meta_entity.idProperty is null and skip_id is not defined %}
 
     /**
-    * @var int
-    * @ORM\Column(name="id", type="integer")
-    * @ORM\Id
-    * @ORM\GeneratedValue(strategy="AUTO")
-    */
+     * @var int
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
     private $id;
 {% endif %}
 {%- for property in meta_entity.properties %}


### PR DESCRIPTION
All lines (except the first, starting with `/**`) of the $id property _docblock_ are missing a space.